### PR TITLE
Update docker builds

### DIFF
--- a/steps/gcp-step-cloud-run-deploy/Dockerfile
+++ b/steps/gcp-step-cloud-run-deploy/Dockerfile
@@ -1,4 +1,14 @@
 FROM google/cloud-sdk:alpine
+RUN set -eux ; \
+    mkdir -p /tmp/ni && \
+    cd /tmp/ni && \
+    wget https://packages.nebula.puppet.net/sdk/ni/v1/ni-v1-linux-amd64.tar.xz && \
+    wget https://packages.nebula.puppet.net/sdk/ni/v1/ni-v1-linux-amd64.tar.xz.sha256 && \
+    echo "$( cat ni-v1-linux-amd64.tar.xz.sha256 )  ni-v1-linux-amd64.tar.xz" | sha256sum -c - && \
+    tar -xvJf ni-v1-linux-amd64.tar.xz && \
+    mv ni-v1*-linux-amd64 /usr/local/bin/ni && \
+    cd - && \
+    rm -fr /tmp/ni
 RUN apk --no-cache add bash ca-certificates curl git jq openssh && update-ca-certificates
 COPY "./step.sh" "/step.sh"
 ENTRYPOINT []

--- a/steps/gcp-step-cloud-run-deploy/step.yaml
+++ b/steps/gcp-step-cloud-run-deploy/step.yaml
@@ -1,61 +1,37 @@
-# The schema version. Required. Must be exactly the string "integration/v1".
 apiVersion: integration/v1
-
-# The schema kind. Required. Must be one of "Query", "Step", or "Trigger"
-# corresponding to its directory location.
 kind: Step
-
-# The name of the action. Required. Must be exactly the name of the directory
-# containing the action.
-name: gcp-step-cloud-run-deploy
-
-# The version of the action. Required. Must be an integer. If specified in the
-# directory name, must be exactly the version in the directory name.
+name: cloud-run-deploy
 version: 3
-
-# High-level phrase describing what this action does. Required.
 summary: Cloud run deploy
 
-# Single-paragraph explanation of what this action does in more detail.
-# Optional. Markdown.
-description: Deploys a GCP cloud run service revision.
+description: |
+  Deploys a GCP cloud run service revision.
 
-# URL or path relative to this file to an icon or icons representing this
-# action. Optional. Defaults to the integration icon.
-icon:
-
-# The mechanism to use to construct this step. Required. Must be an action
-# builder. See the Builders section below.
 build:
-  # The schema version for builders. Required. For now, must be the exact
-  # string "build/v1". We may consider supporting custom third-party builders
-  # in the future.
   apiVersion: build/v1
-
-  # The builder to use. Required.
   kind: Docker
 
 publish:
   repository: relaysh/gcp-step-cloud-run-deploy
 
 schemas:
-  spec: 
+  spec:
     source: file
     file: spec.schema.json
 
 examples:
   - summary: Deploy to Google Cloud Run
-    content: 
+    content:
       apiVersion: v1
       kind: Step
       name: gcp-cloud-run-deploy
       image: relaysh/gcp-step-cloud-run-deploy
       spec:
         credentials:
-          service-account.json: !Secret service-account-base64
-        project: !Parameter gcpProject
-        service: !Parameter serviceName
-        region: !Parameter gcpRegion
+          service-account.json: ${secrets.service-account-base64}
+        project: ${parameters.gcpProject}
+        service: ${parameters.serviceName}
+        region: ${parameters.gcpRegion}
         image:
-          repository: !Parameter imageRepository
-          tag: !Parameter imageTag
+          repository: ${parameters.imageRepository}
+          tag: ${parameters.imageTag}

--- a/steps/rollout-undo/Dockerfile
+++ b/steps/rollout-undo/Dockerfile
@@ -1,4 +1,14 @@
 FROM google/cloud-sdk:alpine
+RUN set -eux ; \
+    mkdir -p /tmp/ni && \
+    cd /tmp/ni && \
+    wget https://packages.nebula.puppet.net/sdk/ni/v1/ni-v1-linux-amd64.tar.xz && \
+    wget https://packages.nebula.puppet.net/sdk/ni/v1/ni-v1-linux-amd64.tar.xz.sha256 && \
+    echo "$( cat ni-v1-linux-amd64.tar.xz.sha256 )  ni-v1-linux-amd64.tar.xz" | sha256sum -c - && \
+    tar -xvJf ni-v1-linux-amd64.tar.xz && \
+    mv ni-v1*-linux-amd64 /usr/local/bin/ni && \
+    cd - && \
+    rm -fr /tmp/ni
 RUN apk --no-cache add bash ca-certificates curl git jq openssh && update-ca-certificates
 RUN gcloud components install kubectl
 COPY "./step.sh" "/step.sh"

--- a/steps/rollout-undo/step.yaml
+++ b/steps/rollout-undo/step.yaml
@@ -4,7 +4,8 @@ name: rollout-undo
 version: 5
 summary: Undo the rollout of a Kubernetes Deployment
 
-description: Rolls back a failing Kubernetes deployment to its
+description: |
+  Rolls back a failing Kubernetes deployment to its
   previous state, using 'kubectl rollout undo'.
 
 build:
@@ -34,8 +35,8 @@ examples:
       name: gcp-rollback
       image: relaysh/gcp-step-rollout-undo
       spec:
-        google: !Connection { type: gcp, name: relay-service-account }
-        deployment: !Parameter serviceName
-        namespace: !Parameter namespace
-        cluster: !Parameter cluster
-        zone: !Parameter zone
+        google: ${connections.gcp.relay-service-account}
+        deployment: ${parameters.serviceName}
+        namespace: ${parameters.namespace}
+        cluster: ${parameters.cluster}
+        zone: ${parameters.zone}


### PR DESCRIPTION
* Adds missing `ni` binary to `gcp-step-cloud-run-deploy` and `gcp-step-undo-rollout`
* Updates those steps to use the new expression language.

Note: Most of the folders, step names, and examples need to be updated, but leaving that for a subsequent PR.