### PR TITLE
Add steps for suspending and resuming GCP instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The following steps are available in this integration:
 | [gcp-step-instance-list](/steps/gcp-step-instance-list) | List GCP instances |
 | [gcp-step-instance-start](/steps/gcp-step-instance-start) | Start GCP instances |
 | [gcp-step-instance-stop](/steps/gcp-step-instance-stop) | Stops GCP instances |
+| [gcp-step-instance-suspend](/steps/gcp-step-instance-suspend) | Suspends GCP instances |
 | [gcp-step-instance-reset](/steps/gcp-step-instance-reset) | Resets GCP instances |
 | [gcp-step-disk-delete](/steps/gcp-step-disk-delete) | Delete GCP disks |
 | [gcp-step-disk-list](/steps/gcp-step-disk-list) | List GCP disks |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following steps are available in this integration:
 | [gcp-step-instance-stop](/steps/gcp-step-instance-stop) | Stops GCP instances |
 | [gcp-step-instance-suspend](/steps/gcp-step-instance-suspend) | Suspends GCP instances |
 | [gcp-step-instance-reset](/steps/gcp-step-instance-reset) | Resets GCP instances |
+| [gcp-step-instance-resume](/steps/gcp-step-instance-resume) | Resumes GCP instances |
 | [gcp-step-disk-delete](/steps/gcp-step-disk-delete) | Delete GCP disks |
 | [gcp-step-disk-list](/steps/gcp-step-disk-list) | List GCP disks |
 | [rollout-undo](/steps/rollout-undo) | Roll back a GKE Deployment on a cluster |

--- a/steps/gcp-step-instance-resume/Dockerfile
+++ b/steps/gcp-step-instance-resume/Dockerfile
@@ -1,0 +1,9 @@
+FROM relaysh/core:latest-python
+RUN pip --no-cache-dir install google-api-python-client
+COPY "./step.py" "/step.py"
+ENTRYPOINT []
+CMD ["python3", "/step.py"]
+
+LABEL "org.opencontainers.image.title"="Resume GCP instances"
+LABEL "org.opencontainers.image.description"="This task resumes instances in GCP"
+LABEL "com.puppet.nebula.sdk.version"="v1"

--- a/steps/gcp-step-instance-resume/README.md
+++ b/steps/gcp-step-instance-resume/README.md
@@ -1,0 +1,3 @@
+# gcp-step-instance-resume
+
+This GCP step container resumes a given set of instances using the beta API. For more information, check out [GCP documentation here](https://cloud.google.com/compute/docs/reference/rest/beta/instances/resume).

--- a/steps/gcp-step-instance-resume/spec.schema.json
+++ b/steps/gcp-step-instance-resume/spec.schema.json
@@ -1,0 +1,45 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"type": "object",
+	"properties": {
+		"google": {
+			"type": "object",
+			"description": "A mapping of GCP account configuration.",
+			"properties": {
+				"service_account_info": {
+					"type": "object",
+					"x-relay-connectionType": "gcp",
+					"description": "A Relay Google Cloud Platform (GCP) connection to use",
+					"properties": {
+						"serviceAccountKey": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"serviceAccountKey"
+					]
+				},
+				"zone": {
+					"type": "string",
+					"description": "The GCP zone to use (for example, `us-central1-a`)."
+				}
+			},
+			"required": [
+				"service_account_info",
+				"zone"
+			]
+		},
+		"instances": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"description": "The list of instances"
+		}
+	},
+	"required": [
+		"google",
+		"instances"
+	],
+	"additionalProperties": false
+}

--- a/steps/gcp-step-instance-resume/step.py
+++ b/steps/gcp-step-instance-resume/step.py
@@ -1,0 +1,52 @@
+import googleapiclient.discovery
+
+from google.oauth2 import service_account
+from relay_sdk import Interface, Dynamic as D
+import json
+
+def slice(orig, keys):
+    return {key: orig[key] for key in keys if key in orig}
+
+def do_resume_instance(compute, project_id, zone, name):
+    print('Resuming instance {0}'.format(name))
+    result = compute.instances().resume(project=project_id, zone=zone, instance=name).execute()
+    return result['items'] if 'items' in result else []
+
+def resume_instances(instances):
+    # For security purposes we whitelist the keys that can be fed in to the
+    # google oauth library. This prevents workflow users from feeding arbitrary
+    # data in to that library.
+    service_account_info_keys = [
+        "type",
+        "project_id",
+        "private_key_id",
+        "private_key",
+        "client_email",
+        "client_id",
+        "auth_uri",
+        "token_uri",
+        "auth_provider_x509_cert_url",
+        "client_x509_cert_url",
+    ]
+
+    zone = relay.get(D.google.zone)
+
+    if not zone:
+        print("Missing `google.zone` parameter on step configuration.")
+        exit(1)
+
+    # TODO: How to validate all the required data is present here?
+    service_account_info=slice(json.loads(relay.get(D.google.service_account_info)['serviceAccountKey']), service_account_info_keys)
+
+    credentials = service_account.Credentials.from_service_account_info(service_account_info)
+    compute = googleapiclient.discovery.build("compute", "beta", credentials=credentials)
+
+    for instance in instances:
+        if isinstance(instance, dict):
+            do_resume_instance(compute, project_id=credentials.project_id, zone=zone, name=instance["name"])
+        else:
+            do_resume_instance(compute, project_id=credentials.project_id, zone=zone, name=instance)
+
+if __name__ == "__main__":
+    relay = Interface()
+    resume_instances(relay.get(D.instances))

--- a/steps/gcp-step-instance-resume/step.yaml
+++ b/steps/gcp-step-instance-resume/step.yaml
@@ -1,0 +1,58 @@
+# The schema version. Required. Must be exactly the string "integration/v1".
+apiVersion: integration/v1
+
+# The schema kind. Required. Must be one of "Query", "Step", or "Trigger"
+# corresponding to its directory location.
+kind: Step
+
+# The name of the action. Required. Must be exactly the name of the directory
+# containing the action.
+name: gcp-step-instance-resume
+
+# The version of the action. Required. Must be an integer. If specified in the
+# directory name, must be exactly the version in the directory name.
+version: 3
+
+# High-level phrase describing what this action does. Required.
+summary: Resume instances
+
+# Single-paragraph explanation of what this action does in more detail.
+# Optional. Markdown.
+description: Resumes a set of GCP compute instances using the beta API.
+
+# URL or path relative to this file to an icon or icons representing this
+# action. Optional. Defaults to the integration icon.
+icon:
+
+# The mechanism to use to construct this step. Required. Must be an action
+# builder. See the Builders section below.
+build:
+  # The schema version for builders. Required. For now, must be the exact
+  # string "build/v1". We may consider supporting custom third-party builders
+  # in the future.
+  apiVersion: build/v1
+
+  # The builder to use. Required.
+  kind: Docker
+
+publish:
+  repository: relaysh/gcp-step-instance-resume
+
+schemas:
+  spec:
+    source: file
+    file: spec.schema.json
+
+examples:
+- summary: Resume a single compute instance in a GCP account using the beta API
+  content:
+    apiVersion: v1
+    kind: Step
+    name: resume-instances
+    image: relaysh/gcp-step-instance-resume
+    spec:
+      google:
+        service_account_info: !Connection { type: gcp, name: my-gcp-account }
+        zone: !Parameter gcpZone
+      instances:
+      - !Parameter instanceName

--- a/steps/gcp-step-instance-suspend/Dockerfile
+++ b/steps/gcp-step-instance-suspend/Dockerfile
@@ -1,0 +1,9 @@
+FROM relaysh/core:latest-python
+RUN pip --no-cache-dir install google-api-python-client
+COPY "./step.py" "/step.py"
+ENTRYPOINT []
+CMD ["python3", "/step.py"]
+
+LABEL "org.opencontainers.image.title"="Suspend GCP instances"
+LABEL "org.opencontainers.image.description"="This task suspends instances in GCP"
+LABEL "com.puppet.nebula.sdk.version"="v1"

--- a/steps/gcp-step-instance-suspend/README.md
+++ b/steps/gcp-step-instance-suspend/README.md
@@ -1,0 +1,3 @@
+# gcp-step-instance-suspend
+
+This GCP step container suspends a given set of instances using the beta API. For more information, check out [GCP documentation here](https://cloud.google.com/compute/docs/reference/rest/beta/instances/suspend).

--- a/steps/gcp-step-instance-suspend/spec.schema.json
+++ b/steps/gcp-step-instance-suspend/spec.schema.json
@@ -1,0 +1,45 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"type": "object",
+	"properties": {
+		"google": {
+			"type": "object",
+			"description": "A mapping of GCP account configuration.",
+			"properties": {
+				"service_account_info": {
+					"type": "object",
+					"x-relay-connectionType": "gcp",
+					"description": "A Relay Google Cloud Platform (GCP) connection to use",
+					"properties": {
+						"serviceAccountKey": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"serviceAccountKey"
+					]
+				},
+				"zone": {
+					"type": "string",
+					"description": "The GCP zone to use (for example, `us-central1-a`)."
+				}
+			},
+			"required": [
+				"service_account_info",
+				"zone"
+			]
+		},
+		"instances": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"description": "The list of instances"
+		}
+	},
+	"required": [
+		"google",
+		"instances"
+	],
+	"additionalProperties": false
+}

--- a/steps/gcp-step-instance-suspend/step.py
+++ b/steps/gcp-step-instance-suspend/step.py
@@ -1,0 +1,57 @@
+import googleapiclient.discovery
+
+from google.oauth2 import service_account
+from relay_sdk import Interface, Dynamic as D
+import json
+
+def slice(orig, keys):
+    return {key: orig[key] for key in keys if key in orig}
+
+def do_suspend_instance(compute, project_id, zone, name):
+    print('suspending instance {0}'.format(name))
+    try:
+        result = compute.instances().suspend(project=project_id, zone=zone, instance=name).execute()
+        return result['items'] if 'items' in result else []
+    except Exception as e:
+        print('GCP instance {0} failed to suspend. Shutting down. Exception: {1}'.format(name, e))
+        result = compute.instances().stop(project=project_id, zone=zone, instance=name).execute()
+        return result['items'] if 'items' in result else []
+
+def suspend_instances(instances):
+    # For security purposes we whitelist the keys that can be fed in to the
+    # google oauth library. This prevents workflow users from feeding arbitrary
+    # data in to that library.
+    service_account_info_keys = [
+        "type",
+        "project_id",
+        "private_key_id",
+        "private_key",
+        "client_email",
+        "client_id",
+        "auth_uri",
+        "token_uri",
+        "auth_provider_x509_cert_url",
+        "client_x509_cert_url",
+    ]
+
+    zone = relay.get(D.google.zone)
+
+    if not zone:
+        print("Missing `google.zone` parameter on step configuration.")
+        exit(1)
+
+    # TODO: How to validate all the required data is present here?
+    service_account_info=slice(json.loads(relay.get(D.google.service_account_info)['serviceAccountKey']), service_account_info_keys)
+
+    credentials = service_account.Credentials.from_service_account_info(service_account_info)
+    compute = googleapiclient.discovery.build("compute", "beta", credentials=credentials)
+
+    for instance in instances:
+        if isinstance(instance, dict):
+            do_suspend_instance(compute, project_id=credentials.project_id, zone=zone, name=instance["name"])
+        else:
+            do_suspend_instance(compute, project_id=credentials.project_id, zone=zone, name=instance)
+
+if __name__ == "__main__":
+    relay = Interface()
+    suspend_instances(relay.get(D.instances))

--- a/steps/gcp-step-instance-suspend/step.yaml
+++ b/steps/gcp-step-instance-suspend/step.yaml
@@ -1,0 +1,58 @@
+# The schema version. Required. Must be exactly the string "integration/v1".
+apiVersion: integration/v1
+
+# The schema kind. Required. Must be one of "Query", "Step", or "Trigger"
+# corresponding to its directory location.
+kind: Step
+
+# The name of the action. Required. Must be exactly the name of the directory
+# containing the action.
+name: gcp-step-instance-suspend
+
+# The version of the action. Required. Must be an integer. If specified in the
+# directory name, must be exactly the version in the directory name.
+version: 1
+
+# High-level phrase describing what this action does. Required.
+summary: Suspend instances
+
+# Single-paragraph explanation of what this action does in more detail.
+# Optional. Markdown.
+description: Suspends a set of GCP compute instances using the Beta API
+
+# URL or path relative to this file to an icon or icons representing this
+# action. Optional. Defaults to the integration icon.
+icon:
+
+# The mechanism to use to construct this step. Required. Must be an action
+# builder. See the Builders section below.
+build:
+  # The schema version for builders. Required. For now, must be the exact
+  # string "build/v1". We may consider supporting custom third-party builders
+  # in the future.
+  apiVersion: build/v1
+
+  # The builder to use. Required.
+  kind: Docker
+
+publish:
+  repository: relaysh/gcp-step-instance-suspend
+
+schemas:
+  spec:
+    source: file
+    file: spec.schema.json
+
+examples:
+- summary: Suspend a single compute instance in a GCP account using the Beta API
+  content:
+    apiVersion: v1
+    kind: Step
+    name: suspend-instances
+    image: relaysh/gcp-step-instance-suspend
+    spec:
+      google:
+        service_account_info: !Connection { type: gcp, name: my-gcp-account }
+        zone: !Parameter gcpZone
+      instances:
+      - !Parameter instanceName


### PR DESCRIPTION
This PR adds steps to suspend and resume GCP instances using the beta API. We use these steps in our workflows to suspend Kubernetes instances rather than shut them down.